### PR TITLE
Fixed memory issue with volatile store

### DIFF
--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -1,6 +1,6 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <Version>7.2.1</Version>
+    <Version>7.2.2</Version>
     <Description>Maverick User Profile Service - includes all applications and libraries that will manage profiles inside the Maverick environments.</Description>
     <Authors>A/V Solutions 360°</Authors>
     <Company>Bechtle GmbH Systemhaus Bonn</Company>


### PR DESCRIPTION
To prevent Marten from generating code for the same model classes multiple times (thus filling up the memory with assemblies), the types are registered upfront and code generation mode is set to Auto.